### PR TITLE
Add Clangd configuration and GoogleTest integration for C++17 project

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,31 @@
+CompileFlags:
+  Add: [
+    "-std=c++14",
+    "-stdlib=libc++",
+    "-Wall",
+    "-Wextra",
+    "-Werror",
+    "-pedantic",
+  ]
+
+Diagnostics:
+  ClangTidy:
+    Add:
+      - modernize-*
+      - readability-*
+      - performance-*
+      - portability-*
+      - bugprone-*
+    Remove:
+      - modernize-use-trailing-return-type
+
+InlayHints:
+  BlockEnd: Yes
+  Designators: Yes
+  Enabled: Yes
+  ParameterNames: Yes
+  DeducedTypes: Yes
+  TypeNameLimit: 24
+
+Hover:
+  ShowAKA: Yes

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,15 +6,33 @@ project(Phonons VERSION 0.1.0 LANGUAGES C CXX)
 
 # Set C++ standard
 set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Add executables
 add_executable(Phonons main.cpp)
 
-# Add tests
-include(CTest)
-enable_testing()
+# GoogleTest
+include(FetchContent)
+FetchContent_Declare(
+  googletest
+  URL https://github.com/google/googletest/archive/refs/tags/v1.15.2.zip
+)
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+FetchContent_MakeAvailable(googletest)
 
 # Add packaging
 set(CPACK_PROJECT_NAME ${PROJECT_NAME})
 set(CPACK_PROJECT_VERSION ${PROJECT_VERSION})
 include(CPack)
+
+# Add tests
+include(CTest)
+enable_testing()
+
+add_executable(hello_test hello_test.cpp)
+target_link_libraries(hello_test gtest gtest_main)
+
+include(GoogleTest)
+gtest_discover_tests(hello_test)
+
+add_test(NAME HelloTest COMMAND hello_test)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,20 @@
+# CMake minimum version
 cmake_minimum_required(VERSION 3.20)
+
+# Project name and version
 project(Phonons VERSION 0.1.0 LANGUAGES C CXX)
 
+# Set C++ standard
+set(CMAKE_CXX_STANDARD 17)
+
+# Add executables
 add_executable(Phonons main.cpp)
 
+# Add tests
 include(CTest)
 enable_testing()
 
+# Add packaging
 set(CPACK_PROJECT_NAME ${PROJECT_NAME})
 set(CPACK_PROJECT_VERSION ${PROJECT_VERSION})
 include(CPack)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,11 @@ project(Phonons VERSION 0.1.0 LANGUAGES C CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+# Add include directories
+include_directories(include)
+
 # Add executables
 add_executable(Phonons main.cpp)
 
@@ -30,9 +35,8 @@ include(CTest)
 enable_testing()
 
 add_executable(hello_test hello_test.cpp)
-target_link_libraries(hello_test gtest gtest_main)
+target_link_libraries(hello_test GTest::gtest GTest::gtest_main)
+add_test(NAME HelloTest COMMAND hello_test)
 
 include(GoogleTest)
 gtest_discover_tests(hello_test)
-
-add_test(NAME HelloTest COMMAND hello_test)

--- a/hello_test.cpp
+++ b/hello_test.cpp
@@ -1,0 +1,8 @@
+#include <gtest/gtest.h>
+
+TEST(HelloTest, BasicAssertions) {
+    // Expect two strings not to be equal.
+    EXPECT_STRNE("hello", "world");
+    // Expect equality.
+    EXPECT_EQ(7 * 6, 42);
+}


### PR DESCRIPTION
Introduce Clangd settings for improved code analysis and update CMakeLists.txt to support C++17. Integrate GoogleTest and create an initial test for basic assertions. Enhance CMake configuration for better test linking and compile commands export.